### PR TITLE
Handle setup deprecation warnings

### DIFF
--- a/smach/setup.cfg
+++ b/smach/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/smach
+script_dir=$base/lib/smach
 [install]
-install-scripts=$base/lib/smach
+install_scripts=$base/lib/smach

--- a/smach/setup.py
+++ b/smach/setup.py
@@ -13,12 +13,12 @@ setup(
     zip_safe=True,
     maintainer='Isaac I. Y. Saito',
     maintainer_email='gm130s@gmail.com',
-    description='''
-        SMACH is a task-level architecture for rapidly creating complex robot
-        behavior. At its core, SMACH is a ROS-independent Python library to build
-        hierarchical state machines. SMACH is a new library that takes advantage of
-        very old concepts in order to quickly create robust robot behavior with
-        maintainable and modular code.''',
+    description=(
+        'SMACH is a task-level architecture for rapidly creating complex robot '
+        'behavior. At its core, SMACH is a ROS-independent Python library to build '
+        'hierarchical state machines. SMACH is a new library that takes advantage of '
+        'very old concepts in order to quickly create robust robot behavior with '
+        'maintainable and modular code.'),
     license='BSD',
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/smach_ros/setup.cfg
+++ b/smach_ros/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/smach_ros
+script_dir=$base/lib/smach_ros
 [install]
-install-scripts=$base/lib/smach_ros
+install_scripts=$base/lib/smach_ros

--- a/smach_ros/setup.py
+++ b/smach_ros/setup.py
@@ -13,12 +13,12 @@ setup(
     zip_safe=True,
     maintainer='Isaac I. Y. Saito',
     maintainer_email='gm130s@gmail.com',
-    description='''
-        SMACH is a task-level architecture for rapidly creating complex robot
-        behavior. At its core, SMACH is a ROS-independent Python library to build
-        hierarchical state machines. SMACH is a new library that takes advantage of
-        very old concepts in order to quickly create robust robot behavior with
-        maintainable and modular code.''',
+    description=(
+        'SMACH is a task-level architecture for rapidly creating complex robot '
+        'behavior. At its core, SMACH is a ROS-independent Python library to build '
+        'hierarchical state machines. SMACH is a new library that takes advantage of '
+        'very old concepts in order to quickly create robust robot behavior with '
+        'maintainable and modular code.'),
     license='BSD',
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
Warnings:
/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:151: UserWarning: newlines not allowed and will break in the future
  warnings.warn("newlines not allowed and will break in the future")

Starting >>> smach_ros
/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:717: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:717: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
--- stderr: smach_ros